### PR TITLE
Update tools container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,16 @@
-FROM golang:1.10-stretch
-
+FROM golang:1.11-stretch
+ENV CF_CLI_VERSION="6.40.1"
+ENV YQ_VERSION="1.15.0"
+ENV SPRUCE_VERION="1.10.0"
 ENV PACKAGES "unzip curl openssl ca-certificates git jq util-linux gzip bash uuid-runtime coreutils vim tzdata openssh-client gnupg rsync make zip"
-RUN apt-get update && apt-get install -y --no-install-recommends ${PACKAGES}
-RUN curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.33.1" | tar -zx -C /usr/local/bin
-
-RUN curl -L "https://github.com/mikefarah/yq/releases/download/1.15.0/yq_linux_amd64" -o yq && chmod +x yq && mv yq /usr/local/bin/yq
-RUN ln -s /usr/local/bin/yq /usr/local/bin/yaml
-
-RUN curl -L "https://github.com/geofffranks/spruce/releases/download/v1.10.0/spruce-linux-amd64" -o spruce && chmod +x spruce && mv spruce /usr/local/bin/spruce
-
-RUN ln /usr/bin/uuidgen /usr/local/bin/uuid
-
-RUN curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.34.1" | tar -zx -C /usr/local/bin
-RUN cf install-plugin -r CF-Community -f "blue-green-deploy"
-RUN cf install-plugin -r CF-Community -f "autopilot"
-
-RUN curl -L "https://github.com/go-swagger/go-swagger/releases/download/0.13.0/swagger_linux_amd64" -o swagger && chmod +x swagger && mv swagger /usr/local/bin/swagger
-
-RUN mkdir -p /root/.ssh
-
-RUN git config --global user.email "git-ssh@governmentpaas.docker" && \
+RUN apt-get update && apt-get install -y --no-install-recommends ${PACKAGES} && apt-get clean && rm -rf /var/lib/apt/lists/* && \
+    curl -L "https://s3-us-west-1.amazonaws.com/cf-cli-releases/releases/v${CF_CLI_VERSION}/cf-cli_${CF_CLI_VERSION}_linux_x86-64.tgz" | tar -zx -C /usr/local/bin && \
+    curl -L "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -o yq && chmod +x yq && mv yq /usr/local/bin/yq && \
+    ln -s /usr/local/bin/yq /usr/local/bin/yaml && \
+    curl -L "https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERION}/spruce-linux-amd64" -o spruce && chmod +x spruce && mv spruce /usr/local/bin/spruce && \
+    ln /usr/bin/uuidgen /usr/local/bin/uuid && \
+    cf install-plugin -r CF-Community -f "blue-green-deploy" && \
+    cf install-plugin -r CF-Community -f "autopilot" && \
+    mkdir -p /root/.ssh && \
+    git config --global user.email "git-ssh@fil.com" && \
     git config --global user.name "Docker container git-ssh"
-
-RUN apt-get clean
-RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
- update golang to 1.11
- rewrite all execs so they are only in one layer, this should allow to
save some space especially when cleaning apt caches. Right now they were
committed in two different layers
- use variables for versions
- update cf cli to latest